### PR TITLE
feat: Using ESM module format instead of CJS

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ export default {
   input: 'src/index.ts',
   output: {
     dir: 'dist',
-    format: 'cjs',
+    format: 'esm',
     sourcemap: true,
   },
   plugins: [typescript(), image(), json()],


### PR DESCRIPTION
We now have all the countries with their flags inside this library. With the current module definition (CJS) this means that every package that depends on this one will import all of this all the time. 

We're instead switching to a more modern ESM module format that'll only import resources as needed.
