### PR TITLE
1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@popsure/public-models",
-  "version": "1.0.1-alpha.6",
+  "version": "1.0.1-alpha.7",
   "author": "Vincent Audoire <vincent@getpopsure.com>",
   "license": "MIT",
   "private": false,
   "description": "Feather insurance models interface and utilities",
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@popsure/public-models",
-  "version": "1.0.1-alpha.7",
+  "version": "1.0.1-alpha.8",
   "author": "Vincent Audoire <vincent@getpopsure.com>",
   "license": "MIT",
   "private": false,
   "description": "Feather insurance models interface and utilities",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "module": "./dist/index.mjs",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -5,18 +5,17 @@
   "license": "MIT",
   "private": false,
   "description": "Feather insurance models interface and utilities",
-  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "repository": "https://github.com/getPopsure/models",
   "scripts": {
-    "build": "rm -rf dist && tsup src/index.ts --format cjs,esm --dts --sourcemap",
+    "build": "rm -rf dist && tsup src/index.ts --format cjs,esm --dts --sourcemap --minify --loader \".svg=dataurl\"",
     "release": "yarn build && yarn publish --access public",
     "test": "jest"
   },
@@ -31,6 +30,6 @@
     "ts-jest": "^27.1.4",
     "tslib": "^1.11.1",
     "tsup": "^5.12.6",
-    "typescript": "^3.8.3"
+    "typescript": "^4.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popsure/public-models",
-  "version": "1.0.1-alpha.4",
+  "version": "1.0.1-alpha.6",
   "author": "Vincent Audoire <vincent@getpopsure.com>",
   "license": "MIT",
   "private": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4814,10 +4814,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@^4.6.4:
+  version "4.6.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## What this PR does

We're exporting both CJS and ESM as part of our module since ESM is still partially supported. We had some issues with Jest not being able to run tests when an ESM module is imported - this fixes it.

