### PR TITLE
[SIDE-560] Add EU as region, country and EU flag

### DIFF
--- a/src/countryCodes.ts
+++ b/src/countryCodes.ts
@@ -67,6 +67,7 @@ export const allCountryCodes = [
   'ER',
   'EE',
   'ET',
+  'EU',
   'FK',
   'FO',
   'FJ',

--- a/src/countryFlags.ts
+++ b/src/countryFlags.ts
@@ -254,5 +254,6 @@ export const mapCountryFlag: { [K in Alpha2CountryCode]: string } = {
   AQ: `${basePath}aq.png`,
   AS: `${basePath}as.png`,
   YT: `${basePath}fr.png`,
+  EU: `${basePath}eu.png`,
 };
 	

--- a/src/region.ts
+++ b/src/region.ts
@@ -17,5 +17,6 @@ export const regions = [
   'hr',
   'lv',
   'mc',
+  'eu'
 ] as const;
 export type Region = typeof regions[number];

--- a/src/static/countryNames/de.json
+++ b/src/static/countryNames/de.json
@@ -57,6 +57,7 @@
     "SV": "El Salvador",
     "ER": "Eritrea",
     "EE": "Estland",
+    "EU": "Europa",
     "FK": "Falklandinseln",
     "FO": "Färöer",
     "FJ": "Fidschi",

--- a/src/static/countryNames/en.json
+++ b/src/static/countryNames/en.json
@@ -64,6 +64,7 @@
     "DO": "Dominican Republic",
     "EC": "Ecuador",
     "EG": "Egypt",
+    "EU": "Europe",
     "SV": "El Salvador",
     "GQ": "Equatorial Guinea",
     "ER": "Eritrea",


### PR DESCRIPTION
### What this PR does

Adds `EU` as a region and country + EU flag

This update is to account for EU locale addition to website + CMS for EU-wide available policies

Solves:
SIDE-560
