### PR TITLE
feat: [PRO-5293] Adding  (worldwide) locale

### DIFF
--- a/src/countryCodes.ts
+++ b/src/countryCodes.ts
@@ -251,6 +251,6 @@ export const allCountryCodes = [
   'SS',
 ] as const;
 
-export type Alpha2CountryCode = typeof allCountryCodes[number];
+export type Alpha2CountryCode = (typeof allCountryCodes)[number];
 
-export type Alpha2CountryOrRegionCode = Alpha2CountryCode | 'EU';
+export type Alpha2CountryOrRegionCode = Alpha2CountryCode | 'EU' | 'WW';

--- a/src/countryFlags.ts
+++ b/src/countryFlags.ts
@@ -261,4 +261,5 @@ export const mapCountryOrRegionFlag: {
 } = {
   ...mapCountryFlag,
   EU: `${basePath}eu.png`,
+  WW: `${basePath}ww.png`,
 };

--- a/src/static/countryNames/de.json
+++ b/src/static/countryNames/de.json
@@ -251,6 +251,7 @@
     "EH": "Westsahara",
     "CF": "Zentralafrikanische Republik",
     "CY": "Zypern",
-    "XK": "Kosovo"
+    "XK": "Kosovo",
+    "WW": "Weltweit"
   }
 }

--- a/src/static/countryNames/en.json
+++ b/src/static/countryNames/en.json
@@ -251,6 +251,7 @@
     "RS": "Serbia",
     "SX": "Sint Maarten (Dutch part)",
     "SS": "South Sudan",
-    "XK": "Kosovo"
+    "XK": "Kosovo",
+    "WW": "Worldwide"
   }
 }

--- a/src/static/countryNames/es.json
+++ b/src/static/countryNames/es.json
@@ -251,6 +251,7 @@
     "RS": "Serbia",
     "SX": "San Martín (Países Bajos)",
     "SS": "Sudán del Sur",
-    "XK": "Kosovo"
+    "XK": "Kosovo",
+    "WW": "Mundial"
   }
 }

--- a/src/static/countryNames/es.json
+++ b/src/static/countryNames/es.json
@@ -252,6 +252,6 @@
     "SX": "San Martín (Países Bajos)",
     "SS": "Sudán del Sur",
     "XK": "Kosovo",
-    "WW": "Mundial"
+    "WW": "Mundo"
   }
 }


### PR DESCRIPTION
### What this PR does

We're adding a new country code: `ww`.

### Why is this needed?

We need this in order to enable "Worldwide" locale for https://linear.app/feather-insurance/issue/PRO-5293/exchange-eu-locale-to-ww-locale 

### How to test?

n/a
