### PR TITLE
fix: Add worldwide locale to region array

### DIFF
--- a/src/region.ts
+++ b/src/region.ts
@@ -28,6 +28,7 @@ export const regions = [
   'sk', // Slovakia
   'mc', // Monaco
   'eu', // Europe
+  'ww', // Worldwide
 ] as const;
 export type Region = typeof regions[number];
 


### PR DESCRIPTION
### What this PR does

After releasing v1.7.0, we're getting a compile error on https://github.com/getPopsure/website/blob/df87633978358cacec362c49c7f0b39521c6727b/constants/languages.ts#L36

This is because the newly created `ww` locale wasn't properly added to the regions array.

I'm not really sure this is the right approach, but it'll unblock it at least. It looks like we'll need to have find a proper way of treating "regions" which aren't countries.